### PR TITLE
fix(grouping): adding in some more group types

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,7 +65,12 @@
     {
       "matchDatasources": ["docker", "node", "npm"],
       "semanticCommitType": "ci",
-      "matchPackageNames": ["node", "circleci/node", "cimg/node"],
+      "matchPackageNames": [
+        "node",
+        "circleci/node",
+        "cimg/node",
+        "@types/node"
+      ],
       "versioning": "node"
     },
     {

--- a/default.json
+++ b/default.json
@@ -53,6 +53,12 @@
     {
       "matchUpdateTypes": ["minor", "major", "patch", "pin"],
       "semanticCommitType": "fix",
+      "matchPackagePrefixes": ["aws-xray"],
+      "groupName": "aws-xray"
+    },
+    {
+      "matchUpdateTypes": ["minor", "major", "patch", "pin"],
+      "semanticCommitType": "fix",
       "matchPackagePrefixes": ["cdktf", "cdktf-cli", "constructs", "@cdktf/"],
       "groupName": "cdktf"
     },


### PR DESCRIPTION
## Goal

* Always group `@types/node` with node packages
* always group aws x-ray packages (EX: https://github.com/Pocket/curated-corpus-api/pull/747 and https://github.com/Pocket/curated-corpus-api/pull/748)