### PR TITLE
add config for vulnerabilityAlerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ You also need to ensure the following:
 * [renovate-approve](https://github.com/apps/renovate-approve) is allowed on your repository
 * All dependabot and auto-merge files are removed from your repository. While, not necessary, they will conflict with each other.
 * Allow auto-merge is enabled in your GitHub repository settings. While not necessary this will allow Renovate to use Github's default auto-merging strategy.
+* If you want support for Vulnerability Alerts, ensure that the `Dependency graph` and `Dependabot alerts` options are enabled in `Code security and analysis` for your repo. Checks for vulnerability alerts are based off dependabot alerts, which reference the [GitHub Advisory Database](https://github.com/advisories) for packages with reported vulnerabilities. Checks for dependencies with active advisories:
+  * Are performed freely at any time.
+  * Do not wait for release stability.
+  * Open PRs immediately, ignoring limits to the number of active PRs.
+  * Do not attempt to group dependencies.
+  * Are marked up differently from other PRs in order to enable driving alerts.
+    * Commit messages are appended with the string `[SECURITY]`.
+    * Branch names end with `*-vulnerability`
 
 
 # Testing

--- a/default.json
+++ b/default.json
@@ -94,5 +94,18 @@
         "matchDepTypes": ["engines"]
       }
     ]
+  },
+  "vulnerabilityAlerts": {
+    "groupName": null,
+    "schedule": ["at any time"],
+    "dependencyDashboardApproval": false,
+    "stabilityDays": 0,
+    "rangeStrategy": "update-lockfile",
+    "commitMessageSuffix": "[SECURITY]",
+    "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
+    "prCreation": "immediate",
+    "addLabels": ["dependencies"],
+    "branchConcurrentLimit": 0,
+    "prConcurrentLimit": 0
   }
 }


### PR DESCRIPTION
In order for this to function on our repos, there are a few github config requirements:

1. Repos that want vulnerability reports must enable `Dependency graph` in the `Code security and analysis` segment of repo settings. This is already set true in the repos I have spot checked, and any backend dev can do this.
2. Repos that want vulnerability reports must enable `Dependabot alerts` in the `Code security and analysis` segment of repo settings. This is **not** set true in the repos I have spot checked, but any backend dev can do this.
3. The renovate app in GitHub must have "read" permissions for "Vulnerability alerts".  I do not believe this is enabled, and the [associated renovate docs](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) suggest that only organization admins can do this.

I've done a little bit of preliminary planning on alerting around these dependency PRs.

- The moment `Dependabot alerts` is enabled for a repo, we should start getting email notifications for security vulnerabilities.
  - I'm not sure how great of a fit this is. Most people I've talked to seem to be annoyed with github noise and disable emails. I know I have github emails automatically archiving because I haven't found a filtering config I like. This could be improved with other branch naming consistency changes in this repo.
  - **However**, these specific emails get CC'd to security_alert@noreply.github.com, so there is a clean mechanism for filtering these in your email inbox.
  - If we think this might be enough, we could possibly skip merging this PR entirely.

- Branch names and commit messages are both being marked up with distinct features that could drive github actions or circleci workflows.
  - If we want, we could add a specific label as well if that makes things easier (changes required to existing repos and backstage I think).
  - These workflows could trigger slack messages, automatically open jira tickets, or any other notification mechanism we like.