### PR TITLE
feat(digest): removing docker digest pinning for docker compose

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,6 +17,11 @@
       "labels": ["docker-update"]
     },
     {
+      "managers": ["docker-compose"],
+      "updateTypes": ["digest"],
+      "enabled": false
+    },
+    {
       "matchDatasources": ["npm"],
       "stabilityDays": 1
     },


### PR DESCRIPTION
## Goals

Due to Arm computers and Intel computers co-existing we need to disable digest pinning for Docker images for our local development so that users computers can run native instruction sets instead of slower emulated images.