### PR TITLE
Enable dependency dashboard for all non-automerge updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -34,12 +34,6 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
-      "automerge": true
-    },
-    {
-      "matchDatasources": ["npm"],
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "major", "patch", "pin"],
       "dependencyDashboardApproval": false,
       "automerge": true
     },
@@ -54,13 +48,13 @@
       "groupName": "github-actions"
     },
     {
-      "matchUpdateTypes": ["minor", "major", "patch", "pin"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin"],
       "semanticCommitType": "fix",
       "matchPackagePrefixes": ["aws-xray"],
       "groupName": "aws-xray"
     },
     {
-      "matchUpdateTypes": ["minor", "major", "patch", "pin"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin"],
       "semanticCommitType": "fix",
       "matchPackagePrefixes": ["cdktf", "cdktf-cli", "constructs", "@cdktf/"],
       "groupName": "cdktf"
@@ -75,11 +69,6 @@
         "@types/node"
       ],
       "versioning": "node"
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["localstack", "localstack/localstack"],
-      "schedule": ["on tuesday"]
     }
   ],
   "node": {

--- a/default.json
+++ b/default.json
@@ -5,7 +5,9 @@
     "group:recommended",
     ":semanticCommits",
     "workarounds:typesNodeVersioning",
-    "preview:dockerCompose"
+    "preview:dockerCompose",
+    ":dependencyDashboard",
+    ":dependencyDashboardApproval"
   ],
   "labels": ["dependencies"],
   "pinDigests": true,
@@ -29,10 +31,6 @@
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "dependencyDashboardApproval": false,
       "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["minor", "major"],
-      "dependencyDashboardApproval": true
     },
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
From reading the docs, I believe adding the dashboard approval preset is all that's required?

Validates with:
```
> cp default.json renovate.json5 && npx --package renovate -c 'renovate-config-validator'
```

Did a little cleanup while I was here. I believe that the multiple `devDependencies` rules were redundant (the `npm` one was a subset of the rule that remains)? PTAL!