### PR TITLE
fix(deps): requiring dependency approval

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,12 +29,10 @@
     },
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
-      "dependencyDashboardApproval": false,
       "automerge": true
     },
     {
       "matchDepTypes": ["devDependencies"],
-      "dependencyDashboardApproval": false,
       "automerge": true
     },
     {


### PR DESCRIPTION
## Goals

Looks like https://github.com/Pocket/renovate-config/pull/8 didn't get all the dependency approval dashboards