### PR TITLE
fix(digest): stop renovate from pinning docker not in dockerfile

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,30 +10,35 @@
     ":dependencyDashboardApproval"
   ],
   "labels": ["dependencies"],
-  "pinDigests": true,
-  "platformAutomerge": true,
   "suppressNotifications": ["prIgnoreNotification", "onboardingClose"],
   "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"]
+    },
+    {
+      "matchDepTypes": ["devDependencies"]
+    },
     {
       "matchDatasources": ["docker"],
       "labels": ["docker-update"]
     },
     {
-      "managers": ["docker-compose"],
-      "updateTypes": ["digest"],
-      "enabled": false
+      "managers": ["docker-compose", "circleci"],
+      "pinDigests": false
+    },
+    {
+      "managers": ["dockerfile"],
+      "pinDigests": true
     },
     {
       "matchDatasources": ["npm"],
       "stabilityDays": 1
     },
     {
-      "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true
+      "matchUpdateTypes": ["patch", "pin", "digest"]
     },
     {
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true
+      "matchDepTypes": ["devDependencies"]
     },
     {
       "semanticCommitType": "chore",


### PR DESCRIPTION
## Goal

* Stop digest pinning docker images for local development and CI

Almost all of us now use M1 macs, when we digest pin, docker images end up getting pinned to the AMD64 version of the images that require our computers to run emulation, even if a aarch64 image is available. 

To solve this renovate should only digest ping Dockerfile's and not docker-compose or circleci.